### PR TITLE
Add contribute.json to the website

### DIFF
--- a/conf/contribute.json
+++ b/conf/contribute.json
@@ -1,0 +1,22 @@
+{
+  "name": "Rustacean Furs' Wiki",
+  "description": "The Wiki of a community of furry Rust engineers.",
+  "repository": {
+    "url": "https://github.com/rustfurs/wiki",
+    "license": "WTFPL"
+  },
+  "keywords": [
+    "Rust",
+    "Wiki"
+  ],
+  "bugs": {
+      "list": "https://github.com/rustfurs/wiki/issues",
+      "report": "https://github.com/rustfurs/wiki/issues/new"
+  },
+  "participate": {
+      "docs": "https://github.com/rustfurs/wiki/"
+  },
+  "urls": {
+      "prod": "https://wiki.rustfu.rs/"
+  }
+}


### PR DESCRIPTION
[contribute.json] is an initiative from Mozilla to provide human- and machine-readable metadata describing how to contribute to a given web site/service or repository.

[contribute.json]: https://www.contributejson.org/